### PR TITLE
Fix syntax error in DDL query

### DIFF
--- a/src/riab/etl/sql_server/templates/ddl/SOURCE_ID_TO_OMOP_ID_MAP_ddl.sql.jinja
+++ b/src/riab/etl/sql_server/templates/ddl/SOURCE_ID_TO_OMOP_ID_MAP_ddl.sql.jinja
@@ -6,7 +6,7 @@ create table [{{omop_database_catalog}}].[{{omop_database_schema}}].source_id_to
     omop_table varchar(50) not null,
     omop_id integer not null,
     source varchar(50),
-    source_id varchar(255)) not null,
+    source_id varchar(255) not null,
     valid_start_date DATE not null,
     valid_end_date DATE not null,
     invalid_reason varchar(50)


### PR DESCRIPTION
Fix for issue "Syntax error source_id_to_omop_id_map DDL query" #81